### PR TITLE
Add eclipse project setup files

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.6"/>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="src" path="src/main/java"/>
+	<classpathentry kind="src" path="src/main/resources"/>
+	<classpathentry exported="true" kind="lib" path="lib/api-1.0.3.jar"/>
+	<classpathentry exported="true" kind="lib" path="lib/ip-1.0.3.jar"/>
+	<classpathentry kind="output" path="target/classes"/>
+</classpath>

--- a/.project
+++ b/.project
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.openhab.binding.bacnet</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ds.core.builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.pde.PluginNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>


### PR DESCRIPTION
I am currently extending the "oomph setup model" for openhab by adding some missing openhab projects (so that the sources and projects for those projects can be selected when installing the Eclipse IDE with openhab projects using the oomph eclipse installer) (see this PR: https://github.com/openhab/openhab-distro/pull/733). 

@kaikreuzer suggested also adding the bacnet binding; to this end (but, imho, also for other devs who want to contribute to this binding) it  would be useful to have eclipse project config files in the binding sources. This is what this PR  is for.